### PR TITLE
Use remarshal 0.17

### DIFF
--- a/example/default.nix
+++ b/example/default.nix
@@ -1,9 +1,9 @@
-{ mkPnpmPackage, vips, ... }:
+{ mkPnpmPackage, python3, vips, ... }:
 
 mkPnpmPackage {
   src = ./.;
 
   # needed by sharp
-  extraBuildInputs = [ vips ];
+  extraBuildInputs = [ python3 vips ];
   installInPlace = true;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727802920,
-        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
         "type": "github"
       },
       "original": {

--- a/lockfile.nix
+++ b/lockfile.nix
@@ -1,6 +1,6 @@
 { lib
 , runCommand
-, remarshal
+, remarshal_0_17
 , fetchurl
 , ...
 }:
@@ -8,7 +8,7 @@
 with lib;
 rec {
 
-  parseLockfile = lockfile: builtins.fromJSON (readFile (runCommand "toJSON" { } "${remarshal}/bin/yaml2json ${lockfile} $out"));
+  parseLockfile = lockfile: builtins.fromJSON (readFile (runCommand "toJSON" { } "${remarshal_0_17}/bin/yaml2json ${lockfile} $out"));
 
   processLockfile = { registry, lockfile, noDevDependencies }:
     let


### PR DESCRIPTION
changes:

- fix the example (`nix build .#example` fails for me otherwise)
- update nixpkgs
- switch back to an old version of remarshal (remarshal 0.18 broke parsing of moonlight's pnpm-lock.yaml: https://github.com/remarshal-project/remarshal/issues/55)